### PR TITLE
increase waiting time for "grbl" on SerialPort connect 

### DIFF
--- a/server.js
+++ b/server.js
@@ -311,7 +311,7 @@ io.sockets.on('connection', function (appSocket) {
                                 }
                             }, 500);
                         }
-                    }, 500);
+                    }, 1000);
                     if (config.firmwareWaitTime > 0) {
                         setTimeout(function () {
                             // Close port if we don't detect supported firmware after 2s.


### PR DESCRIPTION
I have GRBL1.1e running on Arduino MEGA 2560
The latest LaserWeb4 Binaries didn't connect to the grbl with message: "No supported firmware detected. Closing port COM4"
After some investigation I found the timeout of 500ms before sending "version" to detect Smoothieware was just not enough. I doubled it to 1000ms, now it's running fine