### PR TITLE
Job integration

### DIFF
--- a/config.js
+++ b/config.js
@@ -16,4 +16,8 @@ config.grblWaitTime = process.env.GRBL_WAIT_TIME || 1;
 config.smoothieWaitTime = process.env.SMOOTHIE_WAIT_TIME || 1;
 config.tinygWaitTime = process.env.TINYG_WAIT_TIME || 1;
 
+config.jobOnStart = '';
+config.jobOnFinish = '';
+config.jobOnAbort = '';
+
 module.exports = config;

--- a/server.js
+++ b/server.js
@@ -41,6 +41,7 @@ const chalk = require('chalk');
 const request = require('request'); // proxy for remote webcams
 const grblStrings = require('./grblStrings.js');
 const firmwareFeatures = require('./firmwareFeatures.js');
+const { exec } = require('child_process'); //Support for running OS commands before and after jobs
 
 //var EventEmitter = require('events').EventEmitter;
 //var qs = require('querystring');


### PR DESCRIPTION
Added configuration to run OS Commands at Job Start, Abort, and Finish.
In my setup these command allow integration with other scripts to inform me when the job has finished.  Since this is just an OS command users can implement any kind of action from playing a sound to posting to twitter, or actually doing something useful.
In my case I run small Python script that will set a GPIO pin that is being used to light a "Laser In Operation" warning sign.

I though that putting this into the config.js was a little more secure than making it editable from a web interface.

Examples:
```
config.jobOnStart = 'python ~/lw-JobStart.py'
config.jobOnFinish= 'python ~/lw-JobEnd.py'
config.jobOnAbort = 'python ~/lw-JobEnd.py'
```
