### PR TITLE
Updating docker compatibility

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,3 @@
 .git
 dist
-
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM resin/raspberrypi3-node:7
 
-ADD config.js grblStrings.js LICENSE lw.comm-server.service package.json README.md server.js version.txt /laserweb/
+ADD config.js grblStrings.js firmwareFeatures.js LICENSE lw.comm-server.service package.json README.md server.js version.txt /laserweb/
 ADD app /laserweb/app/
 
 RUN cd /laserweb && npm install

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -2,4 +2,4 @@
 
 cd /laserweb
 
-nice -n -20 npm start
+nice -n -20 node server.js


### PR DESCRIPTION
Added `node_modules` to *.dockerignore* so we definitely dont bring the host deps into the container.

Modified *docker_entrypoint.sh* to execute `node server.js` rather than
`npm start` (because otherwise it doesnt work).

Added `firmwareFeatures.js` to *Dockerfile* ADD. This file is apparently
required for lw to work and was left out.