### PR TITLE
Serialport 6.2.2 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dotenv": "*",
     "node-static": "*",
     "request": "*",
-    "serialport": "^4.0.7",
+    "serialport": "^6.2.2",
     "socket.io": "1.7.x",
     "ws": "^1.1.1"
   },

--- a/server.js
+++ b/server.js
@@ -375,6 +375,7 @@ io.sockets.on('connection', function (appSocket) {
 
                 parser.on('data', function (data) {
 		    data = data.toString().trimStart();
+		    writeLog('Recv: ' + data, 3);
                     if (data.indexOf('ok') === 0) { // Got an OK so we are clear to send
                         if (firmware === 'grbl') {
                             grblBufferSize.shift();

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@
 const config = require('./config');
 const serialport = require('serialport');
 var SerialPort = serialport;
+const Readline = SerialPort.parsers.Readline;
 const websockets = require('socket.io');
 const http = require('http');
 const WebSocket = require('ws');
@@ -179,7 +180,7 @@ io.sockets.on('connection', function (appSocket) {
         if (port) {
             appSocket.emit('connectStatus', 'opened:' + port.path);
             appSocket.emit('activePort', port.path);
-            appSocket.emit('activeBaudRate', port.options.baudRate);
+            appSocket.emit('activeBaudRate', port.settings.baudRate);
         } else {
             appSocket.emit('connectStatus', 'opened:' + connectedTo);
             appSocket.emit('activeIP', connectedTo);
@@ -203,7 +204,7 @@ io.sockets.on('connection', function (appSocket) {
             switch (connectionType) {
             case 'usb':
                 appSocket.emit('activePort', port.path);
-                appSocket.emit('activeBaudRate', port.options.baudRate);
+                appSocket.emit('activeBaudRate', port.settings.baudRate);
                 break;
             case 'telnet':
                 appSocket.emit('activeIP', connectedTo);
@@ -247,7 +248,7 @@ io.sockets.on('connection', function (appSocket) {
             switch (connectionType) {
             case 'usb':
                 appSocket.emit('activePort', port.path);
-                appSocket.emit('activeBaudRate', port.options.baudRate);
+                appSocket.emit('activeBaudRate', port.settings.baudRate);
                 break;
             case 'telnet':
                 appSocket.emit('activeIP', connectedTo);
@@ -288,14 +289,14 @@ io.sockets.on('connection', function (appSocket) {
             switch (connectionType) {
             case 'usb':
                 port = new SerialPort(data[1], {
-                    parser: serialport.parsers.readline('\n'),
-                    baudrate: parseInt(data[2])
+		    parser: new Readline('\n'),
+                    baudRate: parseInt(data[2])
                 });
                 io.sockets.emit('connectStatus', 'opening:' + port.path);
 
                 // Serial port events -----------------------------------------------
                 port.on('open', function () {
-                    io.sockets.emit('activePort', {port: port.path, baudrate: port.options.baudRate});
+                    io.sockets.emit('activePort', {port: port.path, baudrate: port.settings.baudRate});
                     io.sockets.emit('connectStatus', 'opened:' + port.path);
                     if (config.resetOnConnect == 1) {
                         port.write(String.fromCharCode(0x18)); // ctrl-x (needed for rx/tx connection)
@@ -342,7 +343,7 @@ io.sockets.on('connection', function (appSocket) {
                     }
                     //machineSend("M115\n");    // Lets check if its Marlin?
 
-                    writeLog(chalk.yellow('INFO: ') + 'Connected to ' + port.path + ' at ' + port.options.baudRate, 1);
+                    writeLog(chalk.yellow('INFO: ') + 'Connected to ' + port.path + ' at ' + port.settings.baudRate, 1);
                     isConnected = true;
                     connectedTo = port.path;
 


### PR DESCRIPTION
updates serialport use to 6.2.2, a recent release that is compatible with recent npm versions.

main points:
* serialport require lines are a little modified
* options are read from port.settings instead of port.options
* serialport is created differently. ReadLine parser is no longer an option that can be passed into the port constructor. Instead a separate parser object is created and then piped from port.
* data events are moved from port.on('data') to parser.on('data'). They do work from port.on('data') but using that triggers what they call 'flowing mode' which is an unbuffered mode. The readline delimiter is ignored and data is read in 32 byte packets (from what I could tell). This split most data lines up into two, which caused lw.comm-server parsing to fail. Moving to parser.on('data') resolves this.
* laser grbl 1.1g appears to insert a newline before reporting version. data is massaged with a trimStart before parsing begins.