### PR TITLE
Fix nightly build targets to build working executables for Linux and Windows from lw.comm-server and LaserWeb4

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,9 +45,11 @@
     "distlinx86": "export USE_SYSTEM_XORRISO=true&& npm run copy && build --linux --ia32 ",
     "distlinx64": "export USE_SYSTEM_XORRISO=true&& npm run copy && build --linux --x64",
     "copy": "ncp ../LaserWeb4/dist/ app/ --limit=6",
-    "nightlywindows": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distwinx64 && cd ./dist && mv *.exe ../../LaserWeb4-Binaries/win64/ && cd .. && npm run distwinx86 && cd ./dist && mv *.exe ../../LaserWeb4-Binaries/win32/ && cd ../../LaserWeb4-Binaries",
-    "nightlylinux": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distlinx64 && cd ./dist && mv *.exe ../../LaserWeb4-Binaries/linux64/ && cd .. && npm run distlinx86 && cd ./dist && mv *.exe ../../LaserWeb4-Binaries/linux32/ && cd ../../LaserWeb4-Binaries"
-  },
+    "nightlywindows64": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx64 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
+    "nightlywindows32": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx86 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
+    "nightlylinux64": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx64 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/",
+    "nightlylinux32": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx86 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/"
+},
   "keywords": [
     "laserweb",
     "cncweb",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/janschiefer/lw.comm-server.git#fix-linux-build"
+    "url": "git+https://github.com/LaserWeb/lw.comm-server.git"
   },
   "devDependencies": {
     "copyfiles": "1.2.x",
@@ -38,17 +38,16 @@
     "start": "echo \"Please run 'npm run dist' to create a local installer, or run 'npm run nightlylinux' or 'npm run nightlywindows' to build distributable installers for each platform\" ",
     "test": "echo \"Error: no test specified\" && exit 0",
     "update_lw4": "git rm app/ -r -f && cp ../LaserWeb4/dist/. app/ -r -u && git add app/",
-    "dist": "npm run copy && build",
     "distmac": "npm run copy && build --mac ",
     "distwinx86": "npm run copy && build --win --ia32 ",
     "distwinx64": "npm run copy && build --win --x64",
     "distlinx86": "export USE_SYSTEM_XORRISO=true&& npm run copy && build --linux --ia32 ",
     "distlinx64": "export USE_SYSTEM_XORRISO=true&& npm run copy && build --linux --x64",
     "copy": "ncp ../LaserWeb4/dist/ app/ --limit=6",
-    "nightlywindows64": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx64 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
-    "nightlywindows32": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx86 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
+    "nightlywindows64": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distwinx64 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
+    "nightlywindows32": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distwinx86 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
     "nightlylinux64": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distlinx64 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/",
-    "nightlylinux32": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx86 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/"
+    "nightlylinux32": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distlinx86 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/"
   },
   "keywords": [
     "laserweb",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LaserWeb/lw.comm-server.git"
+    "url": "git+https://github.com/janschiefer/lw.comm-server.git#fix-linux-build"
   },
   "devDependencies": {
     "copyfiles": "1.2.x",
@@ -49,7 +49,7 @@
     "nightlywindows32": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx86 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
     "nightlylinux64": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx64 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/",
     "nightlylinux32": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx86 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/"
-},
+  },
   "keywords": [
     "laserweb",
     "cncweb",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "copy": "ncp ../LaserWeb4/dist/ app/ --limit=6",
     "nightlywindows64": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx64 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
     "nightlywindows32": "cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distwinx86 && mkdir -p ../LaserWeb4-Binaries/windows && cp -f ./dist/*.exe ../LaserWeb4-Binaries/windows/",
-    "nightlylinux64": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx64 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/",
+    "nightlylinux64": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git checkout electron_bundler && git pull && npm install && npm run distlinx64 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/",
     "nightlylinux32": "export USE_SYSTEM_XORRISO=true&&cd ../LaserWeb4 && git checkout dev-es6 && git pull && npm run installdev && npm run bundle-dev && cd .. && cd lw.comm-server && git pull && npm install && npm run distlinx86 && mkdir -p ../LaserWeb4-Binaries/linux && cp -f ./dist/*.AppImage ../LaserWeb4-Binaries/linux/"
   },
   "keywords": [


### PR DESCRIPTION
1. Remove the horrible "nightlylinux" and "nighlywindows" targets. Create "nightlylinux64", "nightlylinux32", "nightlywindows64", "nightlywindows32" targets

- The "cp" commands in the original targets had totally wrong paths and the build failed if the executables already existed.

- Add "mkdir" for output directory.

- Linux has ELF executables and not EXE. Also we build an .AppImage archive. Correct this in the build rules.

- Separate x64 and x86 targets. 
Current distributions don't include all required libraries/dependencies for architectures other than the current one when cross-compiling (for example libnode:i386 is missing in most 64-bit distributions). All these dependencies have to be cross-compiled manually. The build would fail for 90 % of the people with the old configuration.

2. Remove "dist" target. Use "distlinx64/86", "distwinx64/86" and "distmac" instead.

There is still the problem, that you need to checkout the branch "electron_bundler" in the scripts of lw.electron-server if you want to build a executable that automatically launches an browser window. This also overwrites your local git-copy of the master branch.
Why is that so?
If you type in the URL  "laserweb:8000" manually, you do not need this.

The build was already (and is still) affected by this ( https://github.com/electron-userland/electron-builder/issues/2462 ) unfixed electron-builder bug. The build for Windows targets fails because of an bug in electron-builder icon-handling. I think this has to do with the mysterious "electron_bundler" branch. I have to look into this...
(maybe the changes to icon handling from my previous commit also need to be done in "electron_bundler").

BTW: Dear god, please stop the "nodejs package manager dependency-insanity" and make npm and git work together in a reasonable way...