### PR TITLE
Fix duration of laser test

### DIFF
--- a/server.js
+++ b/server.js
@@ -2540,7 +2540,7 @@ io.sockets.on('connection', function (appSocket) {
                             laserTestOn = true;
                             appSocket.emit('laserTest', power);
                             if (duration > 0) {
-                                addQ('G4 P' + duration / 1000);
+                                addQ('G4 P' + duration);
                                 addQ('M5');
                                 laserTestOn = false;
                                 setTimeout(function () {
@@ -2556,7 +2556,7 @@ io.sockets.on('connection', function (appSocket) {
                             laserTestOn = true;
                             appSocket.emit('laserTest', power);
                             if (duration > 0) {
-                                addQ('G4 P' + duration / 1000);
+                                addQ('G4 P' + duration);
                                 addQ('M107');
                                 laserTestOn = false;
                                 setTimeout(function () {
@@ -2572,7 +2572,7 @@ io.sockets.on('connection', function (appSocket) {
                             laserTestOn = true;
                             appSocket.emit('laserTest', power);
                             if (duration > 0) {
-                                addQ('G4 P' + duration / 1000);
+                                addQ('G4 P' + duration);
                                 addQ('M106 S0');
                                 laserTestOn = false;
                                 setTimeout(function () {


### PR DESCRIPTION
[Marlin](https://marlinfw.org/docs/gcode/G004.html)([kimbra](https://github.com/MKFirmware/MarlinKimbra/blob/V4_2_9/Documentation/GCodes.md)), [Repetier](https://github.com/repetier/Repetier-Firmware/blob/2bbda51eb6407faf29a09987fd635c86818d32db/src/ArduinoDUE/Repetier/Repetier.ino#L45) and [ReprapFirmware](https://duet3d.dozuki.com/Wiki/Gcode#Section_G4_Dwell) expect 'G4 P' to be in milliseconds. The Laserweb frontend does provide milliseconds, so we should not divide by 1000 in that cases. 

I was furthermore wondering if it wouldn't be more appropriate if the frontend would generate and send the commands for laser on and laser off. In my case (Marlin), for instance, I configured the client to use M3/M5 to start stop the laser and was expecting that this would also impact the laser test function only to find out, that the server is hardcoded to use the fan-control (M106/M107) to start/stop the laser for the laser test.

If that would indeed be desirable, I would gladly try to implement it this way, just wanted to ask first if there was any special reason for always using M106/M107.