### PR TITLE
.env file was ignored / added environment variable for IP address

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,10 @@
-require('dotenv');
-//.load({silent: true});
+require('dotenv').config();
 const path = require('path');
 
 var config = {};
 
 config.webPort = process.env.WEB_PORT || 8000;
+config.IP = process.env.IP || '0.0.0.0';
 config.serverVersion = '4.0.136';
 config.apiVersion = '4.0.7';
 

--- a/server.js
+++ b/server.js
@@ -144,7 +144,7 @@ var app = http.createServer(function (req, res) {
         });
     }
 });
-app.listen(config.webPort);
+app.listen(config.webPort, config.IP);
 var io = websockets.listen(app);
 
 


### PR DESCRIPTION
I installed the server on my Raspberry Pi and wanted to change the port but noticed the .env file got ignored but when i passed the parameters in the command line everything worked. I found the error in the config.js file where the command for dotenv was wrong.

I also added an environment variable for the IP so the server can be configured only to bind to localhost. I did this to secure the interface via an reverse proxy. The default behavior is still to bind to outgoing IP. To change this the the variable IP=127.0.0.1 has to be added to the .env file. This may also be added to the WIKI.