### PR TITLE
Docker use node 16 and udev, generic debian base.

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -15,8 +15,22 @@ docker build -t lw.comm-server .
 ```
 docker run -it --device=/dev/ttyUSB0 --rm -p 8000:8000 --cap-add=sys_nice lw.comm-server
 ```
-- connect to app: http://localhost:8000
+- Connect to app: http://localhost:8000
+
+- Change the `--device=` to point to the correct USB device if necesscary, eg `--device=/dev/ttyACM0` etc.
+- To use a different port change the port mapping in the `docker run` command to `<port number>:8000` and adjust the url you connect to appropriately.
 
 ## Run in background
 If you add `-d` to the docker run command it will start the container in detached mode.
 You can use `docker logs -f <uuid>` to follow the output of this, and `docker stop <uuid>` to stop it.
+
+## Allow hot plugging & selection of connected devices
+**This is NOT recommended, since it involves running the container in `--privileged` mode, which is a [potential security risk](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).**
+- run image:
+_..you have been warned.._
+
+```
+docker run -it -v /dev:/dev --rm -p 8000:8000 --cap-add=sys_nice lw.comm-server
+```
+- when you conenct the app you should be able to see all USB devices in the selection list
+

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -26,9 +26,10 @@ You can use `docker logs -f <uuid>` to follow the output of this, and `docker st
 
 ## Allow hot plugging & selection of connected devices
 **This is NOT recommended, since it involves running the container in `--privileged` mode, which is a [potential security risk](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).**
-- run image:
+
 _..you have been warned.._
 
+- run image:
 ```
 docker run -it -v /dev:/dev --rm -p 8000:8000 --cap-add=sys_nice lw.comm-server
 ```

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -33,5 +33,5 @@ _..you have been warned.._
 ```
 docker run -it -v /dev:/dev --rm -p 8000:8000 --cap-add=sys_nice --privileged lw.comm-server
 ```
-- when you conenct the app you should be able to see all USB devices in the selection list
+- when you connect the app you should be able to see all USB devices in the selection list
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,0 +1,22 @@
+# lw.comm-server Docker Builds
+
+This guide assumes some familiarity with [Docker](https://www.docker.com/), if you are new to Docker please start at: https://docs.docker.com/get-started/
+
+Docker user targets:
+- dev
+
+## Dev (development snapshot)
+You can run the current developement version of the app in Docker using the commands below.
+- build development image:
+```
+docker build -t lw.comm-server .
+```
+- run image:
+```
+docker run -it --device=/dev/ttyUSB0 --rm -p 8000:8000 lw.comm-server
+```
+- connect to app: http://localhost:8000
+
+## Run in background
+If you add `-d` to the docker run command it will start the container in detached mode.
+You can use `docker logs -f <uuid>` to follow the output of this, and `docker stop <uuid>` to stop it.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -3,17 +3,17 @@
 This guide assumes some familiarity with [Docker](https://www.docker.com/), if you are new to Docker please start at: https://docs.docker.com/get-started/
 
 Docker user targets:
-- dev
+- dev (default)
 
-## Dev (development snapshot)
-You can run the current developement version of the app in Docker using the commands below.
+## Dev
+You can build and run lw.comm-server in Docker using the commands below.
 - build development image:
 ```
 docker build -t lw.comm-server .
 ```
 - run image:
 ```
-docker run -it --device=/dev/ttyUSB0 --rm -p 8000:8000 lw.comm-server
+docker run -it --device=/dev/ttyUSB0 --rm -p 8000:8000 --cap-add=sys_nice lw.comm-server
 ```
 - connect to app: http://localhost:8000
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -31,7 +31,7 @@ _..you have been warned.._
 
 - run image:
 ```
-docker run -it -v /dev:/dev --rm -p 8000:8000 --cap-add=sys_nice lw.comm-server
+docker run -it -v /dev:/dev --rm -p 8000:8000 --cap-add=sys_nice --privileged lw.comm-server
 ```
 - when you conenct the app you should be able to see all USB devices in the selection list
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,26 @@
-FROM resin/raspberrypi3-node:10
+FROM node:16-bullseye AS base
+#FROM resin/raspberrypi3-node:10
 
 ADD config.js grblStrings.js firmwareFeatures.js LICENSE lw.comm-server.service package.json README.md server.js version.txt /laserweb/
 ADD app /laserweb/app/
 
-RUN cd /laserweb && npm install
+# Set up Apt, install build tooling and udev
+RUN apt update
+RUN apt install -y build-essential udev
 
+# Expose the port the container will serve on
 EXPOSE 8000
 
+FROM base AS comm-server
+
+# Build lw.comm-server
+RUN cd /laserweb && npm install
+
+FROM comm-server AS dev
+
+# Add the start script
 ADD docker_entrypoint.sh /
 
+# Entrypoint (defaulted)
 ENTRYPOINT ["/docker_entrypoint.sh"]
 CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,3 +24,7 @@ ADD docker_entrypoint.sh /
 # Entrypoint (defaulted)
 ENTRYPOINT ["/docker_entrypoint.sh"]
 CMD []
+
+# Bash shell for debug
+from comm-server as bash
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
This updates the `Dockerfile` to support recent serialport changes and improve cross-platform support.

Changed the base image to the ['official'](https://hub.docker.com/_/node) node16/bullseye image; this brings support for [multiple platforms](https://github.com/nodejs/docker-node/blob/6e8f32de3f620833e563e9f2b427d50055783801/16/bullseye/Dockerfile#L9) (armhf, arm64, i32, x64, ppc), and better supports node serialport + udev.

Added a `DOCKER.md` document to the repo detailing how to build+run with the correct nice setting.

