### PR TITLE
Fix laserTest

### DIFF
--- a/server.js
+++ b/server.js
@@ -3010,12 +3010,12 @@ function laserTest(data) { // Laser Test Fire
                         addQ('G1F1');
                         addQ('M3S' + parseInt(power * maxS / 100));
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             addQ('G4 P' + duration / 1000);
                             addQ('M5S0');
                             laserTestOn = false;
-                            //appSocket.emit('laserTest', 0); //-> Grbl get the real state with status report
+                            //io.sockets.emit('laserTest', 0); //-> Grbl get the real state with status report
                         }
                         send1Q();
                         break;
@@ -3023,7 +3023,7 @@ function laserTest(data) { // Laser Test Fire
                         addQ('M3\n');
                         addQ('fire ' + power + '\n');
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             var divider = 1;
                             if (fDate >= new Date('2017-01-02')) {
@@ -3034,7 +3034,7 @@ function laserTest(data) { // Laser Test Fire
                             addQ('M5');
                             setTimeout(function () {
                                 laserTestOn = false;
-                                appSocket.emit('laserTest', 0);
+                                io.sockets.emit('laserTest', 0);
                             }, duration );
                         }
                         send1Q();
@@ -3043,14 +3043,14 @@ function laserTest(data) { // Laser Test Fire
                         addQ('G1F1');
                         addQ('M3S' + parseInt(power * maxS / 100));
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             addQ('G4 P' + duration / 1000);
                             addQ('M5S0');
                             laserTestOn = false;
                             setTimeout(function () {
                                 laserTestOn = false;
-                                appSocket.emit('laserTest', 0);
+                                io.sockets.emit('laserTest', 0);
                             }, duration );
                         }
                         send1Q();
@@ -3061,14 +3061,14 @@ function laserTest(data) { // Laser Test Fire
                         addQ('M3 S' + parseInt(power * maxS / 100));
                         addQ('M4');
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             addQ('G4 P' + duration);
                             addQ('M5');
                             laserTestOn = false;
                             setTimeout(function () {
                                 laserTestOn = false;
-                                appSocket.emit('laserTest', 0);
+                                io.sockets.emit('laserTest', 0);
                             }, duration );
                         }
                         send1Q();
@@ -3077,14 +3077,14 @@ function laserTest(data) { // Laser Test Fire
                         addQ('G1 F1');
                         addQ('M106 S' + parseInt(power * maxS / 100));
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             addQ('G4 P' + duration);
                             addQ('M107');
                             laserTestOn = false;
                             setTimeout(function () {
                                 laserTestOn = false;
-                                appSocket.emit('laserTest', 0);
+                                io.sockets.emit('laserTest', 0);
                             }, duration);
                         }
                         send1Q();
@@ -3093,14 +3093,14 @@ function laserTest(data) { // Laser Test Fire
                         addQ('G1 F1');
                         addQ('M106 S' + parseInt(power * maxS / 100));
                         laserTestOn = true;
-                        appSocket.emit('laserTest', power);
+                        io.sockets.emit('laserTest', power);
                         if (duration > 0) {
                             addQ('G4 P' + duration);
                             addQ('M106 S0');
                             laserTestOn = false;
                             setTimeout(function () {
                                 laserTestOn = false;
-                                appSocket.emit('laserTest', 0);
+                                io.sockets.emit('laserTest', 0);
                             }, duration);
                         }
                         send1Q();


### PR DESCRIPTION
laserTest threw an error:
```
May 18 16:02:17 raspberrypi lw.comm-server[7831]: laserTest: Power 5, Duration 5000, maxS 1000
May 18 16:02:17 raspberrypi lw.comm-server[7831]: /home/franck/lw.comm-server/server.js:3013
May 18 16:02:17 raspberrypi lw.comm-server[7831]:                         appSocket.emit('laserTest', power);
May 18 16:02:17 raspberrypi lw.comm-server[7831]:                         ^
May 18 16:02:17 raspberrypi lw.comm-server[7831]: ReferenceError: appSocket is not defined
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at laserTest (/home/franck/lw.comm-server/server.js:3013:25)
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at Socket.<anonymous> (/home/franck/lw.comm-server/server.js:2015:9)
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at Socket.emit (events.js:314:20)
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at Socket.emitUntyped (/home/franck/lw.comm-server/node_modules/socket.io/dist/typed-events.js:69:22)
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at /home/franck/lw.comm-server/node_modules/socket.io/dist/socket.js:466:39
May 18 16:02:17 raspberrypi lw.comm-server[7831]:     at processTicksAndRejections (internal/process/task_queues.js:79:11)
```

This PR fixes this issue.