### PR TITLE
GrblHAL compatibility

### DIFF
--- a/lw.comm-server.service
+++ b/lw.comm-server.service
@@ -11,7 +11,7 @@ SyslogIdentifier=lw.comm-server
 WorkingDirectory=/home/pi/lw.comm-server
 User=pi
 #Group=<alternate group>
-Environment=NODE_ENV=production PORT=8000
+Environment=NODE_ENV=production WEB_PORT=8000
 
 [Install]
 WantedBy=multi-user.target

--- a/server.js
+++ b/server.js
@@ -692,7 +692,8 @@ io.sockets.on('connection', function (appSocket) {
 
                     } else if (data.indexOf('Grbl') === 0) { // Check if it's Grbl
                         firmware = 'grbl';
-                        fVersion = data.substr(5, 4); // get version
+                        var versionStart = data.indexOf(' ');
+                        fVersion = data.substr(versionStart, 4); // get version
                         fDate = '';
                         writeLog('GRBL detected (' + fVersion + ')', 1);
                         io.sockets.emit('firmware', {firmware: firmware, version: fVersion, date: fDate});


### PR DESCRIPTION
grblHAL prints "grblHAL 1.1" by default, whereas standard grbl prints "grbl 1.1".

This PR adds compatibility with grblHAL by locating the space before parsing the version number.